### PR TITLE
Use zero width space for @ sanitization instead of an empty comment

### DIFF
--- a/features/mashups/tour-code-manager.js
+++ b/features/mashups/tour-code-manager.js
@@ -1043,11 +1043,11 @@ List: ${bIsExistingTour ? '(Unchanged)' : changedFilesDict[`metadata/list.txt`]}
 
     //console.log(`Trying to create PR at https://github.com/OperationTourCode/${sRepo}/`);
 
-    const sIdentifiedComment = `(${user}) ${sKey}: ${sComment}`;
-
     // Escape @ in user rank so that GitHub doesn't consider it a link to a GH account name
     // \ doesn't work: https://github.com/github/markup/issues/1168
-    const sSanitizedUsername = user.replace(`@`, `@<!-- -->`);
+    const sSanitizedUsername = user.replace(`@`, `@\u200B`);
+
+	const sIdentifiedComment = `(${sSanitizedUsername}) ${sKey}: ${sComment}`;
 
     octokit
     .createPullRequest({


### PR DESCRIPTION
there is still an @ mention in the commit message (e.g. https://github.com/OperationTourCode/OTC/pull/682) so this uses the zero width space over an empty comment so it catches all cases (see commit message used in the PR  (I really hope this trick works as I think it does))

e.g. @​HoeenCoder